### PR TITLE
[WIP]: Filter nodes based on pods selectors for load balancer services 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v2 v2.4.0
-	k8s.io/api v0.21.3
-	k8s.io/apimachinery v0.21.3
+	k8s.io/api v0.21.2
+	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/cloud-provider v0.21.2
-	k8s.io/component-base v0.21.3
+	k8s.io/component-base v0.21.2
 	k8s.io/klog/v2 v2.9.0
-	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471
+	k8s.io/utils v0.0.0-20210527160623-6fdb442a123b
 	kubevirt.io/client-go v0.43.0
-	sigs.k8s.io/controller-runtime v0.9.6
+	sigs.k8s.io/controller-runtime v0.9.2
 )
 
 replace (

--- a/pkg/cloudprovider/kubevirt/loadbalancer.go
+++ b/pkg/cloudprovider/kubevirt/loadbalancer.go
@@ -14,9 +14,9 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -30,8 +30,11 @@ const (
 
 type loadbalancer struct {
 	namespace string
-	client    client.Client
-	config    LoadBalancerConfig
+	// cloudProviderClient is the client for the underlying KubeVirt cluster where VMs are created.
+	cloudProviderClient client.Client
+	// client is the kuberentes cluster client that is constructed out of the created VMs in the KubeVirt cluster.
+	client *kubernetes.Clientset
+	config LoadBalancerConfig
 }
 
 // GetLoadBalancer returns whether the specified load balancer exists, and
@@ -65,6 +68,15 @@ func (lb *loadbalancer) GetLoadBalancerName(ctx context.Context, clusterName str
 // Parameter 'clusterName' is the name of the cluster as presented to kube-controller-manager
 func (lb *loadbalancer) EnsureLoadBalancer(ctx context.Context, clusterName string, service *corev1.Service, nodes []*corev1.Node) (*corev1.LoadBalancerStatus, error) {
 	lbName := lb.GetLoadBalancerName(ctx, clusterName, service)
+	if service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal {
+		matchedNodes, err := lb.filterNodes(service, nodes)
+		if err != nil {
+			klog.Errorf("Failed to filter nodes: %v", err)
+			return nil, err
+		}
+
+		nodes = matchedNodes
+	}
 
 	err := lb.applyServiceLabels(ctx, lbName, service.ObjectMeta.Name, nodes)
 	if err != nil {
@@ -85,7 +97,7 @@ func (lb *loadbalancer) EnsureLoadBalancer(ctx context.Context, clusterName stri
 	if lbExists {
 		if !equality.Semantic.DeepEqual(service.Spec.Ports, lbService.Spec.Ports) {
 			lbService.Spec.Ports = lb.createLoadBalancerServicePorts(service)
-			if err := lb.client.Update(ctx, lbService); err != nil {
+			if err := lb.cloudProviderClient.Update(ctx, lbService); err != nil {
 				klog.Errorf("Failed to update LoadBalancer service: %v", err)
 				return nil, err
 			}
@@ -128,6 +140,16 @@ func (lb *loadbalancer) EnsureLoadBalancer(ctx context.Context, clusterName stri
 // Parameter 'clusterName' is the name of the cluster as presented to kube-controller-manager
 func (lb *loadbalancer) UpdateLoadBalancer(ctx context.Context, clusterName string, service *corev1.Service, nodes []*corev1.Node) error {
 	lbName := lb.GetLoadBalancerName(ctx, clusterName, service)
+	if service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal {
+		matchedNodes, err := lb.filterNodes(service, nodes)
+		if err != nil {
+			klog.Errorf("Failed to filter nodes: %v", err)
+			return err
+		}
+
+		nodes = matchedNodes
+	}
+
 	err := lb.applyServiceLabels(ctx, lbName, service.ObjectMeta.Name, nodes)
 	if err != nil {
 		klog.Errorf("Failed to add nodes to LoadBalancer service: %v", err)
@@ -158,7 +180,7 @@ func (lb *loadbalancer) EnsureLoadBalancerDeleted(ctx context.Context, clusterNa
 		return err
 	}
 	if lbExists {
-		if err := lb.client.Delete(ctx, lbService); err != nil {
+		if err := lb.cloudProviderClient.Delete(ctx, lbService); err != nil {
 			klog.Errorf("Failed to delete LoadBalancer service: %v", err)
 			return err
 		}
@@ -175,7 +197,7 @@ func (lb *loadbalancer) EnsureLoadBalancerDeleted(ctx context.Context, clusterNa
 
 func (lb *loadbalancer) getLoadBalancerService(ctx context.Context, lbName string) (*corev1.Service, bool, error) {
 	var service corev1.Service
-	if err := lb.client.Get(ctx, client.ObjectKey{Name: lbName, Namespace: lb.namespace}, &service); err != nil {
+	if err := lb.cloudProviderClient.Get(ctx, client.ObjectKey{Name: lbName, Namespace: lb.namespace}, &service); err != nil {
 		if errors.IsNotFound(err) {
 			return nil, false, nil
 		}
@@ -209,7 +231,7 @@ func (lb *loadbalancer) createLoadBalancerService(ctx context.Context, lbName st
 		lbService.Spec.HealthCheckNodePort = service.Spec.HealthCheckNodePort
 	}
 
-	if err := lb.client.Create(ctx, lbService); err != nil {
+	if err := lb.cloudProviderClient.Create(ctx, lbService); err != nil {
 		klog.Errorf("Failed to create LB %s: %v", lbName, err)
 		return nil, err
 	}
@@ -233,7 +255,7 @@ func (lb *loadbalancer) createLoadBalancerServicePorts(service *corev1.Service) 
 func (lb *loadbalancer) applyServiceLabels(ctx context.Context, lbName, serviceName string, nodes []*corev1.Node) error {
 	instanceIDs := buildInstanceIDMap(nodes)
 	var allVmis kubevirtv1.VirtualMachineInstanceList
-	if err := lb.client.List(ctx, &allVmis, client.InNamespace(lb.namespace)); err != nil {
+	if err := lb.cloudProviderClient.List(ctx, &allVmis, client.InNamespace(lb.namespace)); err != nil {
 		return fmt.Errorf("Failed to list VMIs: %v", err)
 	}
 	var vmiUIDs []string
@@ -242,7 +264,7 @@ func (lb *loadbalancer) applyServiceLabels(ctx context.Context, lbName, serviceN
 	for _, vmi := range allVmis.Items {
 		if _, ok := instanceIDs[vmi.ObjectMeta.Name]; ok {
 			vmi.ObjectMeta.Labels[serviceLabelKey(lbName)] = serviceName
-			if err := lb.client.Update(ctx, &vmi); err != nil {
+			if err := lb.cloudProviderClient.Update(ctx, &vmi); err != nil {
 				klog.Errorf("Failed to update VMI %s: %v", vmi.ObjectMeta.Name, err)
 			} else {
 				// Remember updated VMI UIDs to find the corresponding pods
@@ -257,7 +279,7 @@ func (lb *loadbalancer) applyServiceLabels(ctx context.Context, lbName, serviceN
 	if err != nil {
 		return fmt.Errorf("Failed to create Pod label selector: %v", err)
 	}
-	if err := lb.client.List(ctx, &vmiPods, client.InNamespace(lb.namespace), client.MatchingLabelsSelector{
+	if err := lb.cloudProviderClient.List(ctx, &vmiPods, client.InNamespace(lb.namespace), client.MatchingLabelsSelector{
 		Selector: labels.NewSelector().Add(*createdByVMIReq),
 	}); err != nil {
 		return fmt.Errorf("Failed to list VMI pods: %v", err)
@@ -266,8 +288,7 @@ func (lb *loadbalancer) applyServiceLabels(ctx context.Context, lbName, serviceN
 	// Apply labels to all found pods
 	for _, pod := range vmiPods.Items {
 		pod.ObjectMeta.Labels[serviceLabelKey(lbName)] = serviceName
-		pod.Spec.EnableServiceLinks = pointer.Bool(false)
-		if err := lb.client.Update(ctx, &pod); err != nil {
+		if err := lb.cloudProviderClient.Update(ctx, &pod); err != nil {
 			klog.Errorf("Failed to update pod %s: %v", pod.ObjectMeta.Name, err)
 		}
 	}
@@ -283,11 +304,11 @@ func (lb *loadbalancer) ensureServiceLabelsDeleted(ctx context.Context, lbName, 
 		}),
 	}
 	var vmis kubevirtv1.VirtualMachineInstanceList
-	if err := lb.client.List(ctx, &vmis, listOptions); err != nil {
+	if err := lb.cloudProviderClient.List(ctx, &vmis, listOptions); err != nil {
 		return fmt.Errorf("Failed to list VMIs: %v", err)
 	}
 	var pods corev1.PodList
-	if err := lb.client.List(ctx, &pods, listOptions); err != nil {
+	if err := lb.cloudProviderClient.List(ctx, &pods, listOptions); err != nil {
 		return fmt.Errorf("Failed to list pods: %v", err)
 	}
 	vmiUIDs := make(map[string]struct{}, len(instanceIDs))
@@ -296,7 +317,7 @@ func (lb *loadbalancer) ensureServiceLabelsDeleted(ctx context.Context, lbName, 
 	for _, vmi := range vmis.Items {
 		if _, ok := instanceIDs[vmi.ObjectMeta.Name]; !ok {
 			delete(vmi.ObjectMeta.Labels, serviceLabelKey(lbName))
-			if err := lb.client.Update(ctx, &vmi); err != nil {
+			if err := lb.cloudProviderClient.Update(ctx, &vmi); err != nil {
 				return fmt.Errorf("Failed to update VMI %s: %v", vmi.ObjectMeta.Name, err)
 			}
 			vmiUIDs[string(vmi.ObjectMeta.UID)] = struct{}{}
@@ -306,7 +327,7 @@ func (lb *loadbalancer) ensureServiceLabelsDeleted(ctx context.Context, lbName, 
 		if podCreatedBy, ok := pod.ObjectMeta.Labels["kubevirt.io/created-by"]; ok {
 			if _, ok := vmiUIDs[podCreatedBy]; ok {
 				delete(pod.ObjectMeta.Labels, serviceLabelKey(lbName))
-				if err := lb.client.Update(ctx, &pod); err != nil {
+				if err := lb.cloudProviderClient.Update(ctx, &pod); err != nil {
 					return fmt.Errorf("Failed to update pod: %s: %v", pod.ObjectMeta.Name, err)
 				}
 			}
@@ -321,6 +342,39 @@ func (lb *loadbalancer) getLoadBalancerCreatePollInterval() time.Duration {
 	}
 	klog.Infof("Creation poll interval '%d' must be > 0. Setting to '%d'", lb.config.CreationPollInterval, defaultLoadBalancerCreatePollInterval)
 	return defaultLoadBalancerCreatePollInterval
+}
+
+func (lb *loadbalancer) filterNodes(service *corev1.Service, nodes []*corev1.Node) ([]*corev1.Node, error) {
+	labelSelector := metav1.LabelSelector{MatchLabels: service.Spec.Selector}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		Limit:         100,
+	}
+
+	podsList, err := lb.client.CoreV1().Pods(service.Namespace).List(context.TODO(), listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list pods: %v", err)
+	}
+
+	var nodesNames = map[string]struct{}{}
+	for _, pod := range podsList.Items {
+		for key, val := range pod.Labels {
+			if s, ok := service.Spec.Selector[key]; ok {
+				if val == s {
+					nodesNames[pod.Spec.NodeName] = struct{}{}
+				}
+			}
+		}
+	}
+
+	var matchedNodes []*corev1.Node
+	for _, node := range nodes {
+		if _, ok := nodesNames[node.Name]; ok {
+			matchedNodes = append(matchedNodes, node)
+		}
+	}
+
+	return matchedNodes, nil
 }
 
 func buildInstanceIDMap(nodes []*corev1.Node) map[string]struct{} {

--- a/pkg/cloudprovider/kubevirt/loadbalancer_test.go
+++ b/pkg/cloudprovider/kubevirt/loadbalancer_test.go
@@ -243,8 +243,8 @@ func TestGetLoadBalancer(t *testing.T) {
 	c := mockclient.NewMockClient(ctrl)
 
 	lb := &loadbalancer{
-		namespace: "test",
-		client:    c,
+		namespace:           "test",
+		cloudProviderClient: c,
 	}
 
 	gomock.InOrder(
@@ -288,8 +288,8 @@ func TestGetLoadBalancerName(t *testing.T) {
 	c := mockclient.NewMockClient(ctrl)
 
 	lb := &loadbalancer{
-		namespace: "test",
-		client:    c,
+		namespace:           "test",
+		cloudProviderClient: c,
 	}
 
 	tests := []struct {
@@ -317,8 +317,8 @@ func TestEnsureLoadBalancer(t *testing.T) {
 	c := mockclient.NewMockClient(ctrl)
 
 	lb := &loadbalancer{
-		namespace: "test",
-		client:    c,
+		namespace:           "test",
+		cloudProviderClient: c,
 		config: LoadBalancerConfig{
 			CreationPollInterval: 1,
 		},
@@ -628,8 +628,8 @@ func TestUpdateLoadBalancer(t *testing.T) {
 	c := mockclient.NewMockClient(ctrl)
 
 	lb := &loadbalancer{
-		namespace: "test",
-		client:    c,
+		namespace:           "test",
+		cloudProviderClient: c,
 	}
 
 	createdByVMINodes12Req, _ := labels.NewRequirement("kubevirt.io/created-by", selection.In, []string{"3546a480-2ec3-11e9-b210-d663bd873d93", "3546a354-2ec3-11e9-b210-d663bd873d93"})
@@ -770,8 +770,8 @@ func TestEnsureLoadBalancerDeleted(t *testing.T) {
 	c := mockclient.NewMockClient(ctrl)
 
 	lb := &loadbalancer{
-		namespace: "test",
-		client:    c,
+		namespace:           "test",
+		cloudProviderClient: c,
 	}
 
 	listOptionsSvc1 := &client.ListOptions{Namespace: "test", LabelSelector: labels.SelectorFromSet(labels.Set{"cloud.kubevirt.io/af6ebf1722bb111e9b210d663bd873d9": "service1"})}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR solves the issue of network traffic forwarding from the load balancer service to the right nodes where the pods that are selected are running. When the externalTrafficPolicy Local is used, then traffic would be only go south-west not east-west which means, if the traffic goes to a node where the selected pod doesn't exists, this request will fail.
 
**Which issue(s) this PR fixes** 
Fixes #https://github.com/kubermatic/kubermatic/issues/9022